### PR TITLE
Display people in a random order

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -92,7 +92,7 @@ get '/countries/:country/legislatures/:legislature/periods/:period/person' do
   csv_url = "https://cdn.rawgit.com/everypolitician/everypolitician-data/#{@legislature[:sha]}/#{@legislative_period[:csv]}"
   @people = CSV.parse(open(csv_url).read, headers: true, header_converters: :symbol)
   already_done = current_user.responses.map(&:politician_id)
-  @people = @people.reject { |person| already_done.include?(person[:id]) }
+  @people = @people.reject { |person| already_done.include?(person[:id]) }.shuffle
   erb :person
 end
 


### PR DESCRIPTION
We don't want to accidentally disadvantage someone by always displaying
them first and then people that are still learning how to play to
categorise them incorrectly. Similarly we don't want to always display
someone last and subsequently have less data on them.

Fixes #16 