### PR TITLE
Simplify back buttons

### DIFF
--- a/views/country.erb
+++ b/views/country.erb
@@ -1,5 +1,5 @@
 <% content_for :back_button do %>
-    <a class="app-header__back" href="/countries"><i class="fa fa-chevron-left fa--space-after"></i>Countries</a>
+    <a class="app-header__back" href="/countries"><i class="fa fa-chevron-left"></i></a>
 <% end %>
 
 <h2 class="page-title"><%= @country[:country] %></h2>

--- a/views/person.erb
+++ b/views/person.erb
@@ -1,7 +1,7 @@
 <% content_for :body_class do %>person-page<% end %>
 
 <% content_for :back_button do %>
-    <a class="app-header__back" href="<%= url "/countries/#{@country[:slug]}" %>"><i class="fa fa-chevron-left fa--space-after"></i>Terms</a>
+    <a class="app-header__back" href="<%= url "/countries/#{@country[:slug]}" %>"><i class="fa fa-chevron-left"></i></a>
 <% end %>
 
 <% if @people.any? %>

--- a/views/sass/_header.scss
+++ b/views/sass/_header.scss
@@ -22,29 +22,24 @@
 .app-header__forward {
     position: absolute;
     text-decoration: none;
-    font-size: 0.8em;
-    top: 50%;
-    margin-top: -0.45em;
+    font-size: 0.9em;
+    padding: 0.5em;
+    top: 0;
 
     @media (min-width: $screen_medium_min) {
         font-size: 1em;
-        top: auto;
-        margin-top: 0;
+        top: -0.5em;
+    }
+
+    .fa {
+        vertical-align: middle;
     }
 }
 
 .app-header__back {
-    left: 0.7em;
-
-    @media (min-width: $screen_medium_min) {
-        left: 0;
-    }
+    left: 0;
 }
 
 .app-header__forward {
-    right: 0.7em;
-
-    @media (min-width: $screen_medium_min) {
-        right: 0;
-    }
+    right: 0;
 }


### PR DESCRIPTION
Remove text labels from back buttons, to avoid ambigous wording
or clashes with header title. And also give buttons a larger
click area.

Fixes #31.