### PR TITLE
Don't show popup when there is an error

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -22,9 +22,6 @@ function saveResponse(response) {
     method: 'POST',
     data: {
       response: response
-    },
-    error: function(xhr) {
-      alert("error: " + xhr.responseText);
     }
   });
 }


### PR DESCRIPTION
The user can't do anything about it so we just ignore it and then the
person will be redisplayed at a later point.

Fixes #32 