### PR TITLE
Don't show people that have gender set already

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -105,7 +105,9 @@ get '/countries/:country/legislatures/:legislature/periods/:period/person' do
   @legislative_period = @legislature[:legislative_periods].find { |lp| lp[:slug] == params[:period] }
   @people = csv_for(@legislature[:sha], @legislative_period[:csv], @legislature[:lastmod])
   already_done = current_user.responses.map(&:politician_id)
-  @people = @people.reject { |person| already_done.include?(person[:id]) }.shuffle
+  @people = @people.reject { |person| already_done.include?(person[:id]) }
+  @people = @people.reject { |person| person[:gender] }
+  @people.shuffle!
   erb :person
 end
 


### PR DESCRIPTION
If we've managed to get gender from the official sources then we don't
want to ask for it again as the official source is probably correct. So
we don't show these people to the user.

Fixes #15 