### PR TITLE
Add a very basic filter to top of Countries list

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -86,4 +86,24 @@ $(function(){
     });
   }
 
+  $('[data-filter-elements]').on('keyup', function(){
+    var $elements = $($(this).attr('data-filter-elements'));
+    var searchText = $.trim($(this).val().toLowerCase());
+
+    if(searchText == ''){
+      $elements.show();
+      return true;
+    }
+
+    $elements.each(function(){
+      var itemText = $(this).text().toLowerCase();
+      var found = itemText.indexOf(searchText) > -1;
+      if(found){
+        $(this).show();
+      } else {
+        $(this).hide();
+      }
+    });
+  });
+
 });

--- a/views/countries.erb
+++ b/views/countries.erb
@@ -12,9 +12,14 @@
     </div>
   <% end %>
 
+  <div class="filter-countries">
+      <label for="filter">Filter countries</label>
+      <input type="text" id="filter" data-filter-elements=".list--all .list__item">
+  </div>
+
   <% unless @countries.empty? %>
     <h3 class="list-heading">All countries</h3>
-    <div class="list list--countries">
+    <div class="list list--countries list--all">
       <% @countries.each do |country| %>
         <a class="list__item" href="<%= url "/countries/#{country[:slug]}" %>">
           <h3><%= country[:country] %></h3>

--- a/views/sass/_countries.scss
+++ b/views/sass/_countries.scss
@@ -1,3 +1,48 @@
 .terms__encouragement {
     text-align: center;
 }
+
+.filter-countries {
+    margin: 2em 0;
+    padding: 1em;
+    background-color: $color_pink;
+    color: #fff;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    position: relative;
+
+    label {
+        display: block;
+        margin-bottom: 0.5em;
+        color: inherit;
+    }
+
+    input {
+        position: relative;
+        display: inline-block;
+        width: 100%;
+        background-color: transparent;
+        color: inherit;
+        border: none;
+        outline: none;
+        font-size: 1.5em;
+        line-height: 1em;
+        padding: 0.2em 0;
+        border-bottom: 1px solid rgba(255,255,255,0.5);
+        margin-bottom: 1px;
+        padding-left: 1.3em; // make room for search icon
+
+        &:focus {
+            border-bottom: 2px solid #fff;
+            margin-bottom: 0;
+        }
+    }
+
+    &:before {
+        @include fa-icon();
+        content: $fa-var-search;
+        position: absolute;
+        bottom: 1.3em;
+        left: 0.8em;
+        font-size: 1.3em;
+    }
+}


### PR DESCRIPTION
For #40.

Very basic right now. Doesn't do anything clever about accented characters or alternative spellings (eg: typing "aland" or "aaland" will not match "Åland"). And it doesn't change the order of the items in the list.

Appears below the user's "recent" countries if they have any, but always above the main list of countries.

![screen shot 2015-07-14 at 17 07 58](https://cloud.githubusercontent.com/assets/739624/8678164/e7c8e6e4-2a4a-11e5-8e6e-04b48a668e91.png)
