### PR TITLE
Don't refer to prior terms unless there are any

### DIFF
--- a/views/country.erb
+++ b/views/country.erb
@@ -16,7 +16,7 @@
                     <div class="progress-bar progress-bar--<%= progress_word(percent_complete_term(@country, legislature, legislative_period)) %>"><div style="width: <%= percent_complete_term(@country, legislature, legislative_period) %>%"></div></div>
                 </a>
                 <% @previous_term_complete = (percent_complete_term(@country, legislature, legislative_period) == 100) %>
-                <% if @first_term && !@previous_term_complete %>
+                <% if @first_term && !@previous_term_complete && legislature[:legislative_periods].length > 1 %>
                     <p class="terms__encouragement">
                     Complete your first term to unlock terms further in the past
                     </p>


### PR DESCRIPTION
It doesn't make sense to say "Complete your first term to unlock terms
further in the past" if there is only 1 term of data available.

Fixes #22 