### PR TITLE
Make sure user gets a name assigned

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,9 @@ class User < Sequel::Model
     create do |user|
       user.provider = auth[:provider]
       user.uid = auth[:uid]
-      user.name = auth[:info][:name]
+      user.name = auth[:info][:name] ||
+        auth[:info][:nickname] ||
+        auth[:info][:email]
     end
   end
 


### PR DESCRIPTION
Sometimes the name isn't provided in a callback (which is technically
against the omniauth spec, but it happens). In these cases we try
falling back first to the nickname, then to the email.

This *should* cover any possible missing information.

Fixes #50 