### PR TITLE
Add progress bar to the person page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -119,6 +119,7 @@ get '/countries/:country/legislatures/:legislature/periods/:period/person' do
     country_code: @country[:code],
     legislature_slug: @legislature[:slug]
   ).map(&:politician_id)
+  @total = @people.size
   @people = @people.reject { |person| already_done.include?(person[:id]) }
   @people = @people.reject { |person| person[:gender] }
   @people.shuffle!

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,6 +14,13 @@ var hideMessages = function hideMessages(){
 
 function loadNewPerson() {
   $('.js-extra-people li:last').prependTo('.js-jtinder ul');
+  var total = $('.progress-bar').data('total');
+  var remaining = $('.js-extra-people li, .js-jtinder li').length;
+  var done = total - remaining;
+  var percent = (done / total) * 100;
+  $('.progress-bar div').animate({
+    width: percent + '%'
+  });
 }
 
 function saveResponse(response) {

--- a/views/person.erb
+++ b/views/person.erb
@@ -20,6 +20,8 @@
     <% end %>
 </ul>
 
+<div class="progress-bar progress-bar--healthy" data-total="<%= @total %>"><div style="width: <%= percent_complete_term(@country, @legislature, @legislative_period) %>%"></div></div>
+
 <div class="controls">
     <a class="controls__other js-person-other" href="#">Other</a>
     <a class="controls__male js-jtinder-dislike" href="#">Male</a>


### PR DESCRIPTION
This gets updated in real-time when picking genders.

Future enhancements (to be ticketed separately)

- Change the color of the bar as the % increases
- Add a background to the bar so it's more obvious where the end is
- Fix the off by one error that occurs because the previous card is still animating and therefore still on the page

For #35 