### PR TITLE
Change landing page greeting if user is new

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -6,7 +6,11 @@
 
 <div class="home-primary">
   <% if current_user %>
-    <h2>Welcome back, <%= current_user.name %>!</h2>
+    <% if current_user.responses.any? %>
+        <h2>Welcome back, <%= current_user.name %>!</h2>
+    <% else %>
+        <h2>Welcome, <%= current_user.name %>!</h2>
+    <% end %>
     <p>Ready to help us categorise the world’s politicians?</p>
     <ul class="home-loggedin">
       <% if current_user.responses.any? %>


### PR DESCRIPTION
When a user signs in for the first time it doesn't make sense to say
"Welcome back", so this adds a conditional to check if they've played
the game in the past.

Fixes #62 