### PR TITLE
Add back link to countries page, and about link to logged in homepage

### DIFF
--- a/views/countries.erb
+++ b/views/countries.erb
@@ -1,3 +1,7 @@
+<% content_for :back_button do %>
+    <a class="app-header__back" href="<%= url '/' %>"><i class="fa fa-chevron-left"></i></a>
+<% end %>
+
 <h2 class="page-title">Pick a country</h2>
 
   <% unless @recent.empty? %>

--- a/views/index.erb
+++ b/views/index.erb
@@ -18,7 +18,10 @@
       <% else %>
         <li><a class="button button--primary" href="/onboarding">Here’s how</a></li>
       <% end %>
-        <li><a class="button button--link button--small" href="<%= url '/logout' %>">Log out</a><li>
+        <li>
+            <a style="margin-right: 0.5em" href="<%= url '/about' %>">About</a> &middot;
+            <a style="margin-left: 0.5em"  href="<%= url '/logout' %>">Log out</a>
+        <li>
     </ul>
   <% else %>
     <p>From Afghanistan to Zimbabwe, there are over 180 parliaments in the world — but what percentage of their members are female?</p>


### PR DESCRIPTION
The simplest fix for #80. The About page isn't massively obvious once you're logged in, but at least it's on the same page it was on before you logged in (the homepage).

Fixes #80.