### PR TITLE
Cache person count for each country

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,3 +30,18 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 task default: :test
+
+namespace :cache do
+  task country_person_counts: :app do
+    countries_json = 'https://github.com/everypolitician/' \
+      'everypolitician-data/raw/master/countries.json'
+    countries = Yajl.load(open(countries_json).read, symbolize_keys: true)
+    countries.each do |country|
+      puts "Caching person count for #{country[:name]}"
+      country_count = CountryCount.find_or_create(country_code: country[:code])
+      counts = country[:legislatures].map { |l| l[:person_count] }
+      country_count.person_count = counts.reduce(:+)
+      country_count.save
+    end
+  end
+end

--- a/app/models.rb
+++ b/app/models.rb
@@ -6,3 +6,4 @@ Sequel::Model.plugin :validation_helpers
 
 require 'app/models/user'
 require 'app/models/response'
+require 'app/models/country_count'

--- a/app/models/country_count.rb
+++ b/app/models/country_count.rb
@@ -1,0 +1,3 @@
+# Caches a count of people in a country
+class CountryCount < Sequel::Model
+end

--- a/db/migrations/004_create_country_counts.rb
+++ b/db/migrations/004_create_country_counts.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  change do
+    create_table(:country_counts) do
+      primary_key :id
+      String :country_code, null: false, unique: true
+      Integer :person_count
+      DateTime :created_at
+      DateTime :updated_at
+    end
+  end
+end


### PR DESCRIPTION
Fetches and caches the person count across legislatures for each country. This makes it much quicker to generate the countries page based on information in the database rather than having to refer to CSVs or JSON files.

The `rake cache:country_person_counts` task will need to run as a background job on a regular basis.

Fixes #69 