### PR TITLE
Cache static assets for 5 minutes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -26,6 +26,7 @@ configure do
     socket_timeout: 1.5,
     socket_failure_delay: 0.2
   )
+  set :static_cache_control, [:public, max_age: 5.minutes] if production?
 end
 
 require 'helpers'
@@ -44,6 +45,7 @@ use OmniAuth::Builder do
 end
 
 get '/*.css' do |filename|
+  cache_control :public, max_age: 5.minutes if settings.production?
   scss :"sass/#{filename}"
 end
 


### PR DESCRIPTION
These could ideally be cached for longer, but we don't currently have
any asset fingerprinting, so this will have to do for now.

Fixes #97 